### PR TITLE
Fix missing import introduced by commit 1c9ee7b

### DIFF
--- a/seqlbtoolkit/embs.py
+++ b/seqlbtoolkit/embs.py
@@ -1,8 +1,9 @@
 import logging
 import torch
 import numpy as np
-from .io import progress_bar
+from .io import Progress
 
+progress_bar = Progress()
 
 logger = logging.getLogger(__name__)
 

--- a/seqlbtoolkit/io.py
+++ b/seqlbtoolkit/io.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = [
-    "progress_bar",
     "ProgressBar",
     "set_logging",
     "log_args",


### PR DESCRIPTION
Commit `1c9ee7b` changed `io.py` and removed the `progress_bar` reference. The module `embs.py` was not updated in that commit, causing import error.